### PR TITLE
Erweiterung für mehrere Studiengange und Dokumentarten pro Vorlesung

### DIFF
--- a/action/download.php
+++ b/action/download.php
@@ -49,7 +49,10 @@ class action_plugin_klausuren_download extends DokuWiki_Action_Plugin {
 		if(empty($_POST['klausur_download']))
 			return;
 
-		$NS = $this->getConf('unterlagenNS').'/'.$_POST['lesson'].'/';
+		$NS = $this->getConf('unterlagenNS').'/';
+		if($_POST['course']!="") $NS .= $_POST['course'].'/';
+		$NS .= $_POST['lesson'].'/';
+		if($_POST['doctype']!="") $NS .= $_POST['doctype'].'/';
 		$NS = cleanID($NS);
 
 		// check authes
@@ -62,13 +65,14 @@ class action_plugin_klausuren_download extends DokuWiki_Action_Plugin {
 		// Check if post data is valid
 		$filter = function($var) { return !preg_match('/^\d{4}(ws|ss)$/', $var); };
 		$filtered = array_filter($_POST['klausur_download'], $filter);
-		if(!empty($filtered) || !preg_match('/^\w+$/', $_POST['lesson'])) {
+		if(!empty($filtered) || !preg_match('/^\w+$/', $_POST['lesson']) || !preg_match('/^(?:\w+)?$/', $_POST['course']) || !preg_match('/^(?:\w+)?$/', $_POST['doctype'])) {
+			//msg("Fehler im System. Dateiupload fehlgeschlagen.", -1);
 			msg("Fehler im System. Dateiupload fehlgeschlagen.", -1);
 			return;
 		}
 	 
 		$helper =& plugin_load('helper', 'klausuren_download');
-		$zip = $helper->downloadAsZip($_POST['klausur_download'], $_POST['lesson']);
+		$zip = $helper->downloadAsZip($_POST['klausur_download'], $_POST['lesson'], $_POST['course'], $_POST['doctype']);
 
 		if($zip == null) {
 			msg("Es traten Fehler beim verpacken der Dateien auf.", -1);

--- a/action/upload.php
+++ b/action/upload.php
@@ -34,7 +34,10 @@ class action_plugin_klausuren_upload extends DokuWiki_Action_Plugin {
 	 */
 	function files_uploaded(&$event, $param) {
 
-		$NS = $this->getConf('unterlagenNS').'/'.$_POST['lesson'].'/';
+		$NS = $this->getConf('unterlagenNS').'/';
+		if($_POST['course']!="") $NS .= $_POST['course'].'/';
+		$NS .= $_POST['lesson'].'/';
+		if($_POST['doctype']!="") $NS .= $_POST['doctype'].'/';
 		$NS = cleanID($NS);
 
 		if(!$_FILES['upload'])
@@ -50,7 +53,10 @@ class action_plugin_klausuren_upload extends DokuWiki_Action_Plugin {
 		// Check if post data is valid
 		if(!in_array($_POST['type'], array('klausur','loesung'))
 			|| !preg_match('/^\d{4}(ws|ss)$/', $_POST['semester'])
-			|| !preg_match('/^\w+$/', $_POST['lesson'])) {
+			|| !preg_match('/^(?:\w+)?$/', $_POST['course'])
+			|| !preg_match('/^\w+$/', $_POST['lesson'])
+			|| !preg_match('/^(?:\w+)?$/', $_POST['doctype'])) {
+			//msg("Fehler im System. Dateiupload fehlgeschlagen.", -1);
 			msg("Fehler im System. Dateiupload fehlgeschlagen.", -1);
 			return;
 		}

--- a/helper/helper.php
+++ b/helper/helper.php
@@ -71,9 +71,20 @@ class helper_plugin_klausuren_helper extends Dokuwiki_Plugin {
 		return strtoupper(preg_replace('/(\d{4})(ws|ss)/', '$2 $1', $sem));
 	}
 
-	function getKlausurStatus($semester, $lesson){
-        $filepath = DOKU_INC."data/media/".$this->getConf('unterlagenNS').'/'.$lesson;
-        $pagepath = DOKU_INC."data/pages/".$this->getConf('unterlagenNS').'/'.$lesson;
+	function getKlausurStatus($semester, $lesson, $course="", $doctype=""){
+        $filepath = DOKU_INC."data/media/".$this->getConf('unterlagenNS');
+        $pagepath = DOKU_INC."data/pages/".$this->getConf('unterlagenNS');
+		if($course!="") {
+			$filepath .= '/'.$course;
+			$pagepath .= '/'.$course;
+		}
+		$filepath .= '/'.$lesson;
+		$pagepath .= '/'.$lesson;
+		if($doctype!="") {
+			$filepath .= '/'.$doctype;
+			$pagepath .= '/'.$doctype;
+		}
+
 		$klausurFilename = $lesson."_".$semester."_klausur";
 		$solutionFilename = $lesson."_".$semester."_loesung";
 

--- a/helper/upload.php
+++ b/helper/upload.php
@@ -29,6 +29,8 @@ class helper_plugin_klausuren_upload extends Dokuwiki_Plugin {
 		$form->addElement(formSecurityToken());
 		$form->addHidden('page', hsc($ID));
 		$form->addHidden('lesson', $data['lesson']);
+		$form->addHidden('course', $data['course']);
+		$form->addHidden('doctype', $data['doctype']);
 		$form->addElement(form_makeFileField('upload', "", 'upload_file', '',
 		   	array('accept' => 'application/pdf')));
 		$form->addElement('<br>');

--- a/syntax/main.php
+++ b/syntax/main.php
@@ -30,7 +30,7 @@ class syntax_plugin_klausuren_main extends DokuWiki_Syntax_Plugin {
 	}
 
 	function connectTo($mode) {
-		$this->Lexer->addSpecialPattern('\{\{klausuren>[A-Za-z0-9]+?\}\}',$mode,'plugin_klausuren_main');
+		$this->Lexer->addSpecialPattern('\{\{klausuren>(?:\w{1,3}\/)?\w+?(?:>\w+?)?\}\}',$mode,'plugin_klausuren_main');
 	}
 
 	/**
@@ -40,8 +40,11 @@ class syntax_plugin_klausuren_main extends DokuWiki_Syntax_Plugin {
 	function handle($match, $state, $pos, &$handler){
 
 		// Grep for lesson
-		$lesson = substr($match, 12, -2);
-		return array('lesson' => $lesson);
+		preg_match('/\{\{klausuren>(?:(\w{1,3})\/)?(\w+?)(?:>(\w+?))?\}\}/',$match,$data);
+		$lesson = $detail[1];
+		$course = $detail[2];
+		$doctype= isset($detail[3])?isset($detail[3]):'klausur';
+		return array('course' => $data[1], 'lesson' => $data[2], 'doctype' => $data[3]);
 
 	}
 
@@ -52,12 +55,12 @@ class syntax_plugin_klausuren_main extends DokuWiki_Syntax_Plugin {
 		if($mode != 'xhtml')
 			return false;
 
-		for($i=1;$i < $renderer->lastlevel;$i++) {
+		/*for($i=1;$i < $renderer->lastlevel;$i++) {
 			//$renderer->doc .= '</div>';
 			$renderer->section_close();
-		}
+		}*/
 
-		$renderer->doc .= '<h2>Klausuren</h2>';
+		//$renderer->doc .= '<h2>Klausuren</h2>';
 		
 		// Show upload form if user is allowed to upload here
 		if(auth_quickaclcheck($this->getConf('unterlagenNS').'/'.$data['lesson'].':*') >= AUTH_UPLOAD) {
@@ -69,7 +72,7 @@ class syntax_plugin_klausuren_main extends DokuWiki_Syntax_Plugin {
 		
 		// Shows the list of examns
 		$downhelper =& plugin_load('helper','klausuren_download');
-		$renderer->section_open(2);
+		//$renderer->section_open(2);
 		$downhelper->output(&$renderer, $data);
 
 		return true;


### PR DESCRIPTION
Erweiterung, um mehrere Studiengange sowie mehrere Dokumentarten pro Vorlesung abbilden zu können
Syntax: {{klausuren>studiengang/fach>dokumentart}}
beide Erweiterungen können unabhängig voneinenader benutzt oder weggelassen werden

entsprechend die Syntax für klausuren_info.txt -> [dokumentart]...[/dokumentart]
